### PR TITLE
Changed Code to use jQuery lightweight plugin boilerplate.

### DIFF
--- a/paper-collapse.js
+++ b/paper-collapse.js
@@ -1,4 +1,3 @@
-
 /*!
   Paper Collapse v0.4.0
 
@@ -8,34 +7,98 @@
   MIT License http://opensource.org/licenses/MIT
  */
 
-(function() {
-  (function($) {
-    'use strict';
-    $.fn.paperCollapse = function(options) {
-      var settings;
-      settings = $.extend({}, $.fn.paperCollapse.defaults, options);
-      $(this).find('.collapse-card__heading').add(settings.closeHandler).click(function() {
-        if ($(this).closest('.collapse-card').hasClass('active')) {
-          settings.onHide.call(this);
-          $(this).closest('.collapse-card').removeClass('active');
-          $(this).closest('.collapse-card').find('.collapse-card__body').slideUp(settings.animationDuration, settings.onHideComplete);
-        } else {
-          settings.onShow.call(this);
-          $(this).closest('.collapse-card').addClass('active');
-          $(this).closest('.collapse-card').find('.collapse-card__body').slideDown(settings.animationDuration, settings.onShowComplete);
-        }
-      });
-      return this;
-    };
-    $.fn.paperCollapse.defaults = {
-      animationDuration: 400,
-      easing: 'swing',
-      closeHandler: '.collapse-card__close_handler',
-      onShow: function() {},
-      onHide: function() {},
-      onShowComplete: function() {},
-      onHideComplete: function() {}
-    };
-  })(jQuery);
+// the semi-colon before the function invocation is a safety
+// net against concatenated scripts and/or other plugins
+// that are not closed properly.
+;(function ( $, window, document, undefined ) {
 
-}).call(this);
+    // undefined is used here as the undefined global
+    // variable in ECMAScript 3 and is mutable (i.e. it can
+    // be changed by someone else). undefined isn't really
+    // being passed in so we can ensure that its value is
+    // truly undefined. In ES5, undefined can no longer be
+    // modified.
+
+    // window and document are passed through as local
+    // variables rather than as globals, because this (slightly)
+    // quickens the resolution process and can be more
+    // efficiently minified (especially when both are
+    // regularly referenced in your plugin).
+
+    // Create the defaults once
+    var pluginName = "paperCollapse",
+        defaults = {
+          animationDuration: 400,
+          easing: 'swing',
+          closeHandler: '.collapse-card__close_handler',
+          onShow: function() {},
+          onHide: function() {},
+          onShowComplete: function() {},
+          onHideComplete: function() {}
+        };
+
+    // The actual plugin constructor
+    function Plugin( element, options ) {
+        this.element = element;
+
+        // jQuery has an extend method that merges the
+        // contents of two or more objects, storing the
+        // result in the first object. The first object
+        // is generally empty because we don't want to alter
+        // the default options for future instances of the plugin
+        this.options = $.extend( {}, defaults, options) ;
+
+        this._defaults = defaults;
+        this._name = pluginName;
+        this.init();
+    }
+
+    Plugin.prototype = {
+
+        init: function() {
+            // Place initialization logic here
+            // You already have access to the DOM element and
+            // the options via the instance, e.g. this.element
+            // and this.options
+            // you can add more functions like the one below and
+            // call them like so: this.yourOtherFunction(this.element, this.options).
+            var $ele = $(this.element);
+            var opts = this.options;
+
+            $ele.find('.collapse-card__heading').add(opts.closeHandler).click(function() {
+              if ($ele.closest('.collapse-card').hasClass('active')) {
+                opts.onHide.call(this);
+                $ele.closest('.collapse-card').removeClass('active');
+                $ele.closest('.collapse-card').find('.collapse-card__body').slideUp(opts.animationDuration, opts.onHideComplete);
+              } else {
+                opts.onShow.call(this);
+                $ele.closest('.collapse-card').addClass('active');
+                $ele.closest('.collapse-card').find('.collapse-card__body').slideDown(opts.animationDuration, opts.onShowComplete);
+              }
+            });
+            
+        },
+
+        destroy: function(el, options) {
+            // some logic
+            $(this.element).removeData();
+            $(this.element).find('.collapse-card__heading').unbind( "click" );
+        }
+    };
+
+    // A really lightweight plugin wrapper around the constructor,
+    // preventing against multiple instantiations
+    $.fn[pluginName] = function ( options ) {
+      console.log('this is: ', this)
+        return this.each(function () {
+            if (!$.data(this, "plugin_" + pluginName)) {
+                $.data(this, "plugin_" + pluginName,
+                new Plugin( this, options ));
+            }
+            else if (typeof options === 'string' && options[0] !== '_' && options === 'destroy') {
+                $.data(this, "plugin_" + pluginName).destroy(this, options);
+            }
+        });
+    };
+
+})( jQuery, window, document );


### PR DESCRIPTION
Changes include:
1) Fixed multiple instantiations bug.
The following can be called again to refresh plugin if new items added programmatically. Previously, the existing paper cards would open and close if the method below was called.
$('.collapse-card').paperCollapse();

2) Added destroy method. 
$('.collapse-card').paperCollapse('destroy');